### PR TITLE
Unify POST handling

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,7 +29,7 @@ WriteMakefile(
     BUILD_REQUIRES => {
         'Test::Most'       => '0.33',
         'Test::MockObject' => '1.20140408',
-        'Test::Exception'  => '0.32',
+        'Test::Warnings'   => '0.014',
     },
     META_MERGE => {
         resources => {

--- a/lib/Business/TrueLayer.pm
+++ b/lib/Business/TrueLayer.pm
@@ -90,6 +90,7 @@ sub test_signature ( $self ) {
     $self->api_post(
         '/test-signature',
         { nonce => "9f952b2e-1675-4be8-bb39-6f4343803c2f" },
+        my $expect_json = 0,
     );
 
     return 1;

--- a/lib/Business/TrueLayer/Authenticator.pm
+++ b/lib/Business/TrueLayer/Authenticator.pm
@@ -24,14 +24,6 @@ use Mojo::UserAgent;
 use Carp qw/ croak /;
 use JSON;
 
-has [ qw/ auth_host / ] => (
-    is        => 'ro',
-    isa       => 'Str',
-    required  => 0,
-    lazy      => 1,
-    default   => sub { "auth." . shift->host },
-);
-
 has 'scope' => (
     is        => 'rw',
     isa       => 'ArrayRef',
@@ -70,7 +62,7 @@ sub _authenticate ( $self ) {
         return $self;
     }
 
-    my $url = "https://" . $self->auth_host . "/connect/token";
+    my $url = "https://" . $self->host . "/connect/token";
     my $json = JSON->new->utf8->canonical->encode(
         {
             grant_type    => 'client_credentials',

--- a/lib/Business/TrueLayer/Authenticator.pm
+++ b/lib/Business/TrueLayer/Authenticator.pm
@@ -71,73 +71,16 @@ sub _authenticate ( $self ) {
     }
 
     my $url = "https://" . $self->auth_host . "/connect/token";
-    my $res = $self->_ua->post(
-        $url,
-        => {
-            'Accept'       => 'application/json',
-            'Content-Type' => 'application/json',
-        },
-        => json => {
+    my $json = JSON->new->utf8->canonical->encode(
+        {
             grant_type    => 'client_credentials',
             client_id     => $self->client_id,
             client_secret => $self->client_secret,
             scope         => join( " ",$self->scope->@* ),
         }
-    )->result;
+    );
 
-    my $type = $res->headers->content_type;
-    my $code = $res->code;
-
-    croak( "TrueLayer POST $url returned $code with no MIME type" )
-        unless defined $type;
-    croak( "TrueLayer POST $url returned $code $type not JSON, status line: "
-               . $res->message)
-        unless $type =~ m!\Aapplication/(?:problem\+)?JSON\b!i;
-
-    my $body = $res->body;
-
-    croak( "TrueLayer POST $url returned $code with an empty body" )
-        unless length $body;
-
-    my $res_content = try sub {
-        JSON->new->canonical->decode( $body );
-    },
-    catch_default sub {
-        croak( "TrueLayer POST $url returned $code with malformed JSON length @{[ length $body ]}: $_" );
-    };
-    croak( "TrueLayer POST $url returned $code JSON $res_content" )
-                 unless ref $res_content eq 'HASH';
-
-    unless( $res->is_success ) {
-        my $title = $res_content->{title};
-        if ( length $title ) {
-            # This is looking like an error format we expect:
-            # https://docs.truelayer.com/docs/payments-api-errors
-            my $detail = $res_content->{detail};
-            my $message = defined $detail ? "$title - $detail" : $title;
-
-            croak( "TrueLayer POST $url returned $code: $message" );
-        }
-
-        my $error = $res_content->{error};
-        if ( length $error ) {
-            # This is looking like the error format for the Access tokens
-            # and the Data API
-            # https://docs.truelayer.com/reference/generateaccesstoken
-            my $detail = $res_content->{error_description};
-            my $message = defined $detail ? "'$error' - $detail" : "'$error'";
-            # There's no : in this message so that we distinguish it from the
-            # message generated for the croak above.
-            # (ie we can tell which format the API is actually responding
-            # with, whatever the docs might claim)
-            croak( "TrueLayer POST $url returned $code $message" );
-        }
-
-        # This is not in spec:
-        croak( "TrueLayer POST $url returned $code with JSON keys "
-                   . join( ', ', map { "'$_'" } sort keys %$res_content )
-                   . ' and status line: '  . $res->message);
-    }
+    my $res_content = $self->_ua_request( $url, $json );
 
     # If any of these are missing, we get "interesting" errors from Moose
     # constraint violations.

--- a/lib/Business/TrueLayer/Request.pm
+++ b/lib/Business/TrueLayer/Request.pm
@@ -53,6 +53,16 @@ has api_host => (
     }
 );
 
+has auth_host => (
+    is        => 'ro',
+    isa       => 'Str',
+    required  => 0,
+    lazy      => 1,
+    default   => sub ( $self ) {
+        return join( '.','auth',$self->host );
+    }
+);
+
 has payment_host => (
     is        => 'ro',
     isa       => 'Str',
@@ -93,7 +103,7 @@ has 'authenticator' => (
         Business::TrueLayer::Authenticator->new(
             client_id     => $self->client_id,
             client_secret => $self->client_secret,
-            host          => $self->host,
+            host          => $self->auth_host,
             _ua           => $self->_ua,
         );
     },

--- a/lib/Business/TrueLayer/Request.pm
+++ b/lib/Business/TrueLayer/Request.pm
@@ -193,9 +193,12 @@ sub _ua_request (
         $expect_json = 1;
     }
 
-    my $type = $res->headers->content_type;
     my $code = $res->code;
 
+    # no content
+    return if $code == '204';
+
+    my $type = $res->headers->content_type;
     croak( "TrueLayer $method $url returned $code with no MIME type" )
         unless defined $type;
 

--- a/t/business/truelayer.t
+++ b/t/business/truelayer.t
@@ -25,7 +25,7 @@ isa_ok(
 subtest '->merchant_accounts' => sub {
 
     no warnings qw/ once redefine /;
-    *Business::TrueLayer::Request::api_get = sub {
+    local *Business::TrueLayer::Request::api_get = sub {
         return {
             items => [ {
                 'id' => '5b7adbf4-f289-48a7-b451-bc236443397c',
@@ -57,7 +57,7 @@ subtest '->merchant_accounts' => sub {
 subtest '->create_payment' => sub {
 
     no warnings qw/ once redefine /;
-    *Business::TrueLayer::Request::api_post = sub {
+    local *Business::TrueLayer::Request::api_post = sub {
         return {
             "id" => "SOMEID",
             "user" => {
@@ -142,5 +142,16 @@ sub _payment_args {
         "status" => "authorization_required"
     };
 }
+
+subtest '->test_signature' => sub {
+
+    # "no content"
+    no warnings qw/ once redefine /;
+    local *Business::TrueLayer::Request::api_post = sub {
+        return;
+    };
+
+    ok( $TrueLayer->test_signature,'->test_signature' );
+};
 
 done_testing();

--- a/t/business/truelayer.t
+++ b/t/business/truelayer.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 
 use_ok( 'Business::TrueLayer' );
 isa_ok(

--- a/t/business/truelayer/authenticator.t
+++ b/t/business/truelayer/authenticator.t
@@ -2,17 +2,19 @@
 
 use strict;
 use warnings;
+use feature qw/ signatures postderef /;
 
 use Test::Most;
 use Test::Warnings;
 use Test::MockObject;
 use JSON qw/ encode_json /;
+no warnings qw/ experimental::signatures experimental::postderef /;
 
 use_ok( 'Business::TrueLayer::Authenticator' );
 
 isa_ok(
     my $Authenticator = Business::TrueLayer::Authenticator->new(
-        _ua => my $mo = Test::MockObject->new,
+        _ua => my $ua = Test::MockObject->new,
         client_id => 'TL-CLIENT-ID',
         client_secret => 'super-secret-client-secret',
         host => '/dev/null',
@@ -20,16 +22,197 @@ isa_ok(
     'Business::TrueLayer::Authenticator',
 );
 
-$mo->mock( post => sub { shift } );
-$mo->mock( result  => sub { shift } );
+my @testcases = ({
+    name => 'payments',
+    desc => 'successful authentication',
+    code => 200,
+    type => 'application/json',
+    body => {
+        access_token  => "AAABBBCCCDDD",
+        expires_in    => 3600,
+        token_type    => "Bearer",
+    }
+}, {
+    name => 'wrong',
+    desc => 'wrong MIME type',
+    code => 200,
+    type => 'text/plain',
+    body => 'https://humanstate.bamboohr.com/careers',
+    want => qr!\bTrueLayer POST .* returned 200 text/plain not JSON\b!,
+}, {
+    name => 'missing',
+    desc => 'no MIME type',
+    code => 200,
+    body => 'https://youtu.be/gJPbuNtH8aQ',
+    want => qr!\bTrueLayer POST .* returned 200 with no MIME type\b!,
+}, {
+    name => 'empty',
+    desc => 'empty JSON',
+    code => 200,
+    type => 'application/json',
+    body => "",
+    # Implication of this message is that it was declared to be JSON:
+    want => qr!\bTrueLayer POST .* returned 200 with an empty body\b!,
+}, {
+    name => 'not',
+    desc => 'not JSON',
+    code => 200,
+    type => 'application/json',
+    body => 'https://youtu.be/t0UwYMDeTjI',
+    want => qr!\bTrueLayer POST .* returned 200 with malformed JSON length 28: malformed JSON\b!,
+}, {
+    name => 'array',
+    desc => 'JSON array',
+    code => 200,
+    type => 'application/json',
+    body => [],
+    # Implication of this message is that it was declared to be JSON:
+    want => qr!\bTrueLayer POST .* returned 200 JSON ARRAY\(!,
+}, {
+    name => 'error',
+    desc => 'access token simple error',
+    code => 400,
+    type => 'application/json',
+    body => {
+        error => 'invalid_client'
+    },
+    want => qr!\bTrueLayer POST .* returned 400 'invalid_client'!
+}, {
+    name => 'deteail',
+    desc => 'access token error with detail',
+    code => 500,
+    type => 'application/json',
+    body => {
+        error => 'internal_server_error',
+        error_description => 'Sorry, we are experiencing technical difficulties. Please try again later.',
+    },
+    want => qr!\bTrueLayer POST .* returned 500 'internal_server_error' - Sorry!
+}, {
+    name => 'bearer',
+    desc => 'Bearer token missing',
+    code => 401,
+    type => 'application/problem+json',
+    body => {
+        type => "https://docs.truelayer.com/docs/error-types#unauthenticated",
+        title => "Unauthenticated",
+        status => 401,
+        detail => "A valid Bearer token must be provided in the Authorization header.",
+        trace_id => "f4d057158ded560d336571800c7a054d",
+    },
+    want => qr!\bTrueLayer POST .* returned 401: Unauthenticated - A valid Bearer token !
+}, {
+    name => 'TI',
+    desc => 'TI signature missing',
+    code => 401,
+    type => 'application/problem+json',
+    body => {
+        type => "https://docs.truelayer.com/docs/error-types#unauthenticated",
+        title => "Unauthenticated",
+        status => 401,
+        detail => "Invalid header `Tl-Signature`. Invalid signature",
+        trace_id => "96ce50247f87f540bb2d86771b3728b8",
+    },
+    want => qr!\bTrueLayer POST .* returned 401: Unauthenticated - Invalid header `Tl-Signature`!
+}, {
+    # Strictly it says CAN, so {} is technically valid as per the RFC.
+    # But that's not very useful, so let's be a bit more stringent...
+    name => 'duff',
+    desc => 'not RFC-7807 JSON',
+    code => 417,
+    message => 'Expectation Failed',
+    type => 'application/problem+json',
+    body => {
+        RFC => 'https://datatracker.ietf.org/doc/html/rfc7807',
+        spec => 'https://datatracker.ietf.org/doc/html/rfc6919',
+    },
+    want => qr!\bTrueLayer POST .* returned 417 with JSON keys 'RFC', 'spec' and status line: Expectation Failed\b!
+}, {
+    name => 'nowt',
+    desc => 'empty problem JSON',
+    code => 411,
+    type => 'application/problem+json',
+    body => "",
+    want => qr!\bTrueLayer POST .* returned 411 with an empty body\b!,
+}, {
+    name => 'rickroll',
+    desc => 'not problem JSON',
+    code => 406,
+    type => 'application/problem+json',
+    body => 'https://youtu.be/mASABAVRVDc',
+    want => qr!\bTrueLayer POST .* returned 406 with malformed JSON length 28: malformed JSON\b!,
+}, {
+    name => 'brew',
+    desc => 'wrong MIME type for error',
+    code => 418,
+    message => "I'm a teapot",
+    type => 'text/plain',
+    body => "short and stout",
+    want => qr!\bTrueLayer POST .* returned 418 text/plain not JSON, status line: I'm a teapot\b!,
+}, {
+    name => 'snafu',
+    desc => 'POSTing to the hosted payment pages',
+    code => 405,
+    message => 'Method Not Allowed',
+    type => 'text/html',
+    body => <<'EOT',
+<head><title>405 Not Allowed</title></head>
+<body>
+<center><h1>405 Not Allowed</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>
+EOT
+    want => qr!\bTrueLayer POST .* returned 405 text/html not JSON, status line: Method Not Allowed\b!,
+});
 
-$mo->mock(
-    body => sub {
-        return encode_json({
-            access_token  => "AAABBBCCCDDD",
-            expires_in    => 3600,
-            token_type    => "Bearer",
-        });
+my %responses;
+my %cache;
+
+for my $testcase ( @testcases ) {
+    my $type = $testcase->{type};
+    my $headers = $cache{$type // ""}
+        //= Test::MockObject->new->set_always( content_type => $type );
+    $responses{$testcase->{name}} = {
+        desc => $testcase->{desc},
+        code => $testcase->{code},
+        headers => $headers,
+        body => ref $testcase->{body}
+            ? encode_json( $testcase->{body} ) : $testcase->{body},
+        message => $testcase->{message}
+            // "testcase '$testcase->{name}' should not have called ->message",
+    };
+}
+
+$ua->mock(
+    post => sub($self, $url, $headers, $generator, $body) {
+        # We aren't going to get unique diagnostics on this, but likely in the
+        # context of the verbose test output it will help with the problems
+        is( $generator, 'json', 'mocked UA called correctly' );
+        # This is a bit of a hack, but we know that we can control this value
+        # from our constructor, so we can cheat and use it to choose our poison:
+        my $name = $body->{scope};
+        my $results = $responses{$name};
+        # This isn't going to end well. This test script is borked.
+        # BAIL_OUT seems a bit overkill, but this script should abort right now:
+        isnt( $results, undef, "No canned response found for $name" )
+            or exit 1;
+        note( "Sending the canned response for $name: $results->{desc}" );
+        my $response = Test::MockObject->new( \$results );
+        $response->mock(
+            result => sub($self) {
+                my $result = Test::MockObject->new();
+                while ( my ($method, $return) = each $$self->%* ) {
+                    # Uncomment this when you have no idea what is failing:
+                    # note( "Mock $method to $return" );
+                    $result->set_always( $method, $return );
+                }
+                $result->mock( is_success => sub($self) {
+                                   $self->code =~ /\A2/;
+                               } );
+                return $result;
+            }
+        );
+        return $response;
     }
 );
 
@@ -44,5 +227,25 @@ ok( ! $Authenticator->_refresh_token,'! ->_refresh_token' );
 is( $Authenticator->_token_type,'Bearer','->_token_type' );
 cmp_ok( $Authenticator->_expires_at,'>',time + 3595,'->_expires_at' );
 ok( ! $Authenticator->_token_is_expired,'! ->_token_is_expired' );
+
+# First entry is the happy path we tested just above
+shift @testcases;
+
+for my $testcase ( @testcases ) {
+    subtest "Failure $testcase->{desc}" => sub {
+        # Re-use the cooked user agent we created above
+        my $Authenticator = Business::TrueLayer::Authenticator->new(
+            _ua => $ua,
+            client_id => 'TL-CLIENT-ID',
+            client_secret => 'super-secret-client-secret',
+            host => '/dev/null',
+            # This selects the failure response:
+            scope => [ $testcase->{name} ],
+        );
+        isa_ok( $Authenticator, 'Business::TrueLayer::Authenticator' );
+        throws_ok( sub { $Authenticator->_authenticate }, $testcase->{want},
+                   'meaningful error reported' );
+    };
+}
 
 done_testing();

--- a/t/business/truelayer/authenticator.t
+++ b/t/business/truelayer/authenticator.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 use Test::MockObject;
 use JSON qw/ encode_json /;
 

--- a/t/business/truelayer/beneficiary.t
+++ b/t/business/truelayer/beneficiary.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 
 use_ok( 'Business::TrueLayer::Beneficiary' );
 

--- a/t/business/truelayer/merchantaccount.t
+++ b/t/business/truelayer/merchantaccount.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 
 use_ok( 'Business::TrueLayer::MerchantAccount' );
 use_ok( 'Business::TrueLayer::MerchantAccount::Identifier' );

--- a/t/business/truelayer/merchantaccount/identifier.t
+++ b/t/business/truelayer/merchantaccount/identifier.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 
 use_ok( 'Business::TrueLayer::MerchantAccount::Identifier' );
 

--- a/t/business/truelayer/payment.t
+++ b/t/business/truelayer/payment.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 
 use_ok( 'Business::TrueLayer::Payment' );
 

--- a/t/business/truelayer/payment/method.t
+++ b/t/business/truelayer/payment/method.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 
 use_ok( 'Business::TrueLayer::Payment::Method' );
 

--- a/t/business/truelayer/provider/filter.t
+++ b/t/business/truelayer/provider/filter.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 
 use_ok( 'Business::TrueLayer::Provider::Filter' );
 

--- a/t/business/truelayer/provider/scheme.t
+++ b/t/business/truelayer/provider/scheme.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 
 use_ok( 'Business::TrueLayer::Provider::Scheme' );
 

--- a/t/business/truelayer/request.t
+++ b/t/business/truelayer/request.t
@@ -2,11 +2,12 @@
 
 use strict;
 use warnings;
+use feature qw/ signatures postderef /;
 
-use FindBin qw/ $Bin /;
 use Test::MockObject;
 use Test::Most;
 use Test::Warnings;
+no warnings qw/ experimental::signatures experimental::postderef /;
 
 use_ok( 'Business::TrueLayer::Request' );
 isa_ok(
@@ -26,58 +27,98 @@ subtest '->idempotency_key' => sub {
     my %unique_keys;
     for ( 1 .. 10 ) {
 
-        ok( 
-            ++$unique_keys{ $Request->idempotency_key } == 1,
+        is(
+            ++$unique_keys{ $Request->idempotency_key }, 1,
             '->idempotency_key is unique'
         );
     }
 };
 
-$ua->mock( post => sub { shift } );
-$ua->mock( get => sub { shift } );
-$ua->mock( result  => sub { shift } );
-$ua->mock( body => sub { } );
 
 $signer->mock( sign_request => sub { 'A..B' } );
 
 $auth->mock( 'access_token' => sub { 'XYZ' } );
 
-subtest 'is_success' => sub {
-    $ua->mock( is_success => sub { 1 } );
+my %status = (
+    code => 200,
+);
 
-    lives_ok(
-        sub { $Request->api_post( '/foo',{} ) },
-        '->api_post',
-    );
+for my $method ( qw( post get ) ) {
+    $ua->mock( $method => sub($self, $url, $headers, @ ) {
+        is( ref $headers, 'HASH', 'headers are a hashdef' );
+        # Yes, strictly these are case insenstive. This test is good enough:
+        like( $headers->{Authorization}, qr/\ABearer /, 'Authorisation header' );
+        if( $method eq 'post' ) {
+            is( $headers->{'Tl-Signature'}, 'A..B', 'JWT in Tl-Signature' );
+            isnt( $headers->{'Idempotency-Key'}, undef, 'Idempotency Key' );
+        }
 
-    lives_ok(
-        sub { $Request->api_get( '/foo' ) },
-        '->api_get',
-    );
-};
+        my $response = Test::MockObject->new();
+        $response->mock(
+            result => sub {
+                my $result = Test::MockObject->new();
+
+                $result->mock( is_success => sub($self) {
+                                   $self->code =~ /\A2/;
+                               } );
+                $result->mock( is_error => sub($self) {
+                                   $self->code =~ /\A[45]/;
+                               } );
+                $result->set_always( body => $method eq 'post' ? '{"p":{}}' : '{"g":[]}' );
+                # This can actually override the previous "defaults"
+                while ( my ($method, $return) = each %status ) {
+                    $result->set_always( $method, $return );
+                }
+
+                return $result;
+            } );
+    });
+}
+
+lives_ok(
+    sub {
+        cmp_deeply( $Request->api_post( '/foo',{} ), { p => {} }, 'post result' );
+    },
+    '->api_post',
+);
+lives_ok(
+    sub {
+        cmp_deeply( $Request->api_get( '/foo' ), { g => [] }, 'get result' );
+    },
+    '->api_get',
+);
 
 subtest 'failures' => sub {
-    $ua->mock( is_success => sub { 0 } );
-    $ua->mock( is_error => sub { 1 } );
-    $ua->mock( message => sub { "error message" } );
+    %status = (
+        code => 400,
+        message => "error message"
+    );
 
     throws_ok(
         sub { $Request->api_post( '/foo',{} ) },
         qr/API POST failed: error message/,
     );
 
-    $ua->mock( is_success => sub { 0 } );
-    $ua->mock( is_error => sub { 0 } );
-    $ua->mock( code => sub { 301 } );
+    {
+        local $TODO = 'GET failures reported as POST';
+    throws_ok(
+        sub { $Request->api_get( '/foo', ) },
+        qr/API GET failed: error message/,
+    );
+    }
+
+    %status = (
+        code => 301,
+    );
 
     throws_ok(
         sub { $Request->api_post( '/foo',{} ) },
         qr/API POST failed > 5 levels of redirect/,
     );
 
-    $ua->mock( is_success => sub { 0 } );
-    $ua->mock( is_error => sub { 0 } );
-    $ua->mock( code => sub { 0 } );
+    %status = (
+        code => 0,
+    );
 
     throws_ok(
         sub { $Request->api_post( '/foo',{} ) },

--- a/t/business/truelayer/request.t
+++ b/t/business/truelayer/request.t
@@ -103,6 +103,17 @@ lives_ok(
     '->api_get, not JSON',
 );
 
+lives_ok(
+    sub {
+        %status = (
+            code => 204,
+            body => undef,
+        );
+        $Request->api_post( '/foo',{} );
+    },
+    '->api_post, no content',
+);
+
 subtest 'failures' => sub {
     %status = (
         code => 400,

--- a/t/business/truelayer/request.t
+++ b/t/business/truelayer/request.t
@@ -6,7 +6,7 @@ use warnings;
 use FindBin qw/ $Bin /;
 use Test::MockObject;
 use Test::Most;
-use Test::Exception;
+use Test::Warnings;
 
 use_ok( 'Business::TrueLayer::Request' );
 isa_ok(

--- a/t/business/truelayer/signer.t
+++ b/t/business/truelayer/signer.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 use Test::MockObject;
 use JSON qw/ encode_json /;
 

--- a/t/business/truelayer/user.t
+++ b/t/business/truelayer/user.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::Most;
+use Test::Warnings;
 
 use_ok( 'Business::TrueLayer::User' );
 

--- a/xt/001_authenticate.t
+++ b/xt/001_authenticate.t
@@ -7,6 +7,7 @@ use FindBin qw/ $Bin /;
 use lib $Bin;
 
 use Test::Most;
+use Test::Warnings;
 use Test::Credentials;
 use Business::TrueLayer;
 

--- a/xt/002_sign.t
+++ b/xt/002_sign.t
@@ -7,6 +7,7 @@ use FindBin qw/ $Bin /;
 use lib $Bin;
 
 use Test::Most;
+use Test::Warnings;
 use Test::Credentials;
 use Business::TrueLayer;
 

--- a/xt/003_merchant_account_details.t
+++ b/xt/003_merchant_account_details.t
@@ -7,6 +7,7 @@ use FindBin qw/ $Bin /;
 use lib $Bin;
 
 use Test::Most;
+use Test::Warnings;
 use Test::Credentials;
 use Business::TrueLayer;
 

--- a/xt/004_create_payment.t
+++ b/xt/004_create_payment.t
@@ -7,6 +7,7 @@ use FindBin qw/ $Bin /;
 use lib $Bin;
 
 use Test::Most;
+use Test::Warnings;
 use Test::Credentials;
 use Business::TrueLayer;
 


### PR DESCRIPTION
* refactor and unify the `POST` code from the Authenticator class with the `POST` and `GET` code in the Request code
* paranoid error handling - the different API endpoints use different formats to report errors - "don't cross the streams" is less of a problem now
* move `auth_host` to  Request, Authenticator only uses `host` internally
* use Test::Warnings in all tests